### PR TITLE
Changes for opcode breakpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Ubuntu:
 
 [![CMake on multiple platforms](https://github.com/X65/emu/actions/workflows/cmake-multi-platform.yml/badge.svg)](https://github.com/X65/emu/actions/workflows/cmake-multi-platform.yml)
 
-Build using CMake and a modern C/C++ compiler.
+Build using CMake and a modern C/C++ compiler. 
 
 > [!TIP]
 > This repository uses submodules.
@@ -64,3 +64,9 @@ Linux
 Windows
 
     > build/emu.exe file=roms/SOTB.xex
+
+### Opcode Breakpoints
+
+The emulator supports opcode based breakpoints, if an specified opcode is executed, the emulator will stop. Possible breakpoint values are EA (NOP) 42 (WDM #xx) and B8 (CLV).
+
+    > build/emu.exe file=roms/SOTB.xex break=EA

--- a/src/args.c
+++ b/src/args.c
@@ -36,7 +36,6 @@ static error_t parse_opt(int key, char* arg, struct argp_state* argp_state) {
         case 'o': args->output_file = arg; break;
         case 'd': args->dap = 1; break;
         case 'p': args->dap_port = arg; break;
-
         case 'l': app_load_labels(arg, false); break;
 
         case ARGP_KEY_ARG:

--- a/src/x65.c
+++ b/src/x65.c
@@ -160,6 +160,7 @@ void app_init(void) {
             joy_type = X65_JOYSTICKTYPE_DIGITAL_12;
         }
     }
+
     x65_desc_t desc = x65_desc(joy_type);
     x65_init(&state.x65, &desc);
     gfx_init(&(gfx_desc_t){
@@ -277,6 +278,14 @@ void app_init(void) {
     if (!delay_input) {
         if (sargs_exists("input")) {
             keybuf_put(sargs_value("input"));
+        }
+    }
+    if (sargs_exists("break")) {
+        int opcode;
+        if (sscanf(sargs_value("break"),"%x",&opcode) == 1) {
+            ui_dbg_control_opcode_break(&state.ui.dbg,true,opcode);
+        } else {
+            fprintf(stderr,"Bad breakpoint opcode %s\n",sargs_value("break"));
         }
     }
 }


### PR DESCRIPTION
PR creates a configureable opcode breakpoint triggered by break=XX in the command line, where XX is a hexadecimal instruction. When any instruction with this value is executed, the debugger halts.